### PR TITLE
docs(home): home page surfaces twelve views, not nine

### DIFF
--- a/src/app/_home/sections/KeyFeatures.tsx
+++ b/src/app/_home/sections/KeyFeatures.tsx
@@ -41,7 +41,7 @@ const features: Feature[] = [
     icon: MonitorIcon,
     title: "Terminal Workstation",
     description:
-      "A keyboard-driven Git workstation with 9 views that brings every tool together in one surface.",
+      "A keyboard-driven Git workstation with 12 views — including conflict resolution, reflog recovery, and a bisect workflow — that brings every tool together in one surface.",
     layout: "tall",
     visual: () => <WorkstationVisual />,
   },
@@ -110,6 +110,9 @@ function CommandsVisual() {
 }
 
 function WorkstationVisual() {
+  // Twelve top-level views, mirroring the LogInkView union in coco's
+  // inkViewModel.ts — keep this list in sync with the workstation
+  // page's tuiViews array.
   const views = [
     "history",
     "status",
@@ -120,6 +123,9 @@ function WorkstationVisual() {
     "stash",
     "worktrees",
     "PR",
+    "conflicts",
+    "reflog",
+    "bisect",
   ]
   return (
     <div className="grid grid-cols-3 gap-1.5">

--- a/src/app/_home/sections/WorkstationTeaser.tsx
+++ b/src/app/_home/sections/WorkstationTeaser.tsx
@@ -25,9 +25,9 @@ const features = [
   },
   {
     icon: LayoutGridIcon,
-    title: "9 specialized views",
+    title: "12 specialized views",
     description:
-      "History, status, diff, compose, branches, tags, stash, worktrees, and pull-request.",
+      "History, status, diff, compose, branches, tags, stash, worktrees, pull-request, conflicts, reflog, and bisect.",
   },
   {
     icon: LayersIcon,


### PR DESCRIPTION
The `/workstation` page was bumped to twelve views in [#15](https://github.com/gfargo/git-co.co/pull/15) but the home-page teaser sections that funnel users into clicking through still claimed nine. Caught during an audit while prepping coco's v0.46.0 release.

## Changed (3 places, 2 files)

**`WorkstationTeaser.tsx`** — bullet that previews the workstation:
```diff
- title: '9 specialized views'
+ title: '12 specialized views'
- description: 'History, status, diff, compose, branches, tags, stash, worktrees, and pull-request.'
+ description: 'History, status, diff, compose, branches, tags, stash, worktrees, pull-request, conflicts, reflog, and bisect.'
```

**`KeyFeatures.tsx`** — `Terminal Workstation` card:
```diff
-  description: 'A keyboard-driven Git workstation with 9 views ...'
+  description: 'A keyboard-driven Git workstation with 12 views — including conflict resolution, reflog recovery, and a bisect workflow — ...'
```
The card description now names the three differentiators most likely to matter to users comparing coco against lazygit / gitui / GitKraken.

**`KeyFeatures.tsx`** — `WorkstationVisual` mini-grid: extended from 9 to 12 cells (added `conflicts`, `reflog`, `bisect`). Kept in sync with the `LogInkView` union in coco's `inkViewModel.ts` — added a comment pointing at that source so the next person who edits this knows where the canonical list lives.

No layout changes; the grid was already 3-column so 12 cells now lay out as four rows instead of three.

## Validation

- [x] `yarn build` — green, all 22 routes
- [x] `yarn lint` — 0 errors (4 pre-existing react-hooks warnings carried over from [#14](https://github.com/gfargo/git-co.co/pull/14))
- [x] All three places now in sync with [#15](https://github.com/gfargo/git-co.co/pull/15)'s workstation page