### PR TITLE
docs(workstation): surface GitHub issue / PR triage in toolbelt + workstation grid

### DIFF
--- a/src/app/_home/sections/Toolbelt.tsx
+++ b/src/app/_home/sections/Toolbelt.tsx
@@ -7,6 +7,8 @@ import {
     ClipboardCheckIcon,
     ScissorsIcon,
     MonitorIcon,
+    CircleDotIcon,
+    GitPullRequestIcon,
     SettingsIcon,
 } from "lucide-react"
 import { track } from "@vercel/analytics/react"
@@ -103,7 +105,7 @@ const commands: (CommandCardProps & { id: string })[] = [
     name: "ui",
     tagline: "Your full terminal workstation",
     description:
-      "Launch the keyboard-driven Git workstation with 9 views: history, status, diff, compose, branches, tags, stash, worktrees, and pull-request.",
+      "Launch the keyboard-driven Git workstation with 15 views: history, status, diff, compose, branches, tags, stash, worktrees, pull-request, PR triage, issues, conflicts, reflog, bisect, and changelog.",
     usage: "coco ui",
     icon: MonitorIcon,
     flags: [
@@ -113,6 +115,44 @@ const commands: (CommandCardProps & { id: string })[] = [
       { flag: "--branch", description: "Filter to a specific branch" },
       { flag: "--path", description: "Filter history to a file path" },
       { flag: "--limit", description: "Limit number of commits loaded" },
+    ],
+  },
+  {
+    id: "issues",
+    name: "issues",
+    tagline: "Triage GitHub issues without leaving your terminal",
+    description:
+      "List, filter, and act on issues for the current repo. Pipe to grep / jq for scripting, or jump to gi inside coco ui for a list-and-inspector triage surface with per-row actions: comment, label, assign, close, reopen.",
+    usage: "coco issues",
+    icon: CircleDotIcon,
+    flags: [
+      { flag: "--state", description: "Filter by state (open, closed, all)" },
+      { flag: "--mine", description: "Shorthand for --assignee @me" },
+      { flag: "--assignee", description: "Filter by assignee login" },
+      { flag: "--author", description: "Filter by author login" },
+      { flag: "--label", description: "Filter by label (comma-separated for AND)" },
+      { flag: "--search", description: "Free-form GitHub search syntax" },
+      { flag: "--json", description: "Machine-readable output for pipelines" },
+      { flag: "--refresh", description: "Force a fresh gh call (5-min disk cache by default)" },
+    ],
+  },
+  {
+    id: "prs",
+    name: "prs",
+    tagline: "Triage GitHub pull requests at the speed of thought",
+    description:
+      "Multi-PR triage list with the full action panel: merge, approve, request changes, close, comment, label, assign — all gated through y-confirm. Filter cycling via f: open / draft / mine / assigned / closed / merged. Hit gP inside coco ui for the inspector view with body, status checks, and reviews.",
+    usage: "coco prs",
+    icon: GitPullRequestIcon,
+    flags: [
+      { flag: "--state", description: "open, closed, merged, all" },
+      { flag: "--draft", description: "Draft PRs only" },
+      { flag: "--mine", description: "PRs you authored (shorthand for --author @me)" },
+      { flag: "--base", description: "PRs targeting a specific base branch" },
+      { flag: "--head", description: "PRs from a specific head branch" },
+      { flag: "--label", description: "Filter by label" },
+      { flag: "--search", description: "Free-form GitHub search syntax" },
+      { flag: "--json", description: "Machine-readable output for pipelines" },
     ],
   },
   {

--- a/src/app/workstation/page.tsx
+++ b/src/app/workstation/page.tsx
@@ -5,6 +5,7 @@ import {
     ArchiveIcon,
     BookOpenIcon,
     ChevronRightIcon,
+    CircleDotIcon,
     ClockIcon,
     CodeIcon,
     DiffIcon,
@@ -12,6 +13,7 @@ import {
     GitBranchIcon,
     GitCompareIcon,
     GitPullRequestIcon,
+    GitPullRequestArrowIcon,
     HistoryIcon,
     MonitorIcon,
     PenToolIcon,
@@ -39,7 +41,7 @@ import { WorkflowsAccordion } from "./WorkflowsAccordion"
 export function generateMetadata(): Metadata {
   const title = "Workstation — Terminal Git Workstation"
   const description =
-    "A keyboard-driven terminal Git workstation with 13 specialized views, chord navigation, AI-powered commits, one-keystroke PR creation, full-screen changelog generation, and customizable themes. No Electron, no mouse required."
+    "A keyboard-driven terminal Git workstation with 15 specialized views — including GitHub issue and PR triage surfaces — chord navigation, AI-powered commits, one-keystroke PR creation, full-screen changelog generation, and customizable themes. No Electron, no mouse required."
 
   return {
     title,
@@ -127,7 +129,19 @@ const tuiViews = [
     icon: GitPullRequestIcon,
     name: "Pull Request",
     chord: ["g", "p"],
-    description: "Review, approve, merge, and comment on PRs",
+    description: "Review, approve, merge, and comment on the current branch's PR",
+  },
+  {
+    icon: GitPullRequestArrowIcon,
+    name: "PR Triage",
+    chord: ["g", "P"],
+    description: "Multi-PR triage list with filter cycling, body / reviews / checks in the inspector, and the full action panel by-number",
+  },
+  {
+    icon: CircleDotIcon,
+    name: "Issues",
+    chord: ["g", "i"],
+    description: "Issue triage list with filter cycling, body / comments in the inspector, and per-row comment / label / assign / close / reopen",
   },
   {
     icon: AlertTriangleIcon,
@@ -165,6 +179,8 @@ const chordKeys = [
   { key: "z", label: "Stash" },
   { key: "w", label: "Worktrees" },
   { key: "p", label: "Pull Request" },
+  { key: "P", label: "PR Triage" },
+  { key: "i", label: "Issues" },
   { key: "x", label: "Conflicts" },
   { key: "r", label: "Reflog" },
   { key: "B", label: "Bisect" },


### PR DESCRIPTION
The triage workflow ([gfargo/coco#882](https://github.com/gfargo/coco/issues/882)) shipped across seven PRs ([#964](https://github.com/gfargo/coco/pull/964), [#965](https://github.com/gfargo/coco/pull/965), [#969](https://github.com/gfargo/coco/pull/969), [#971](https://github.com/gfargo/coco/pull/971), [#972](https://github.com/gfargo/coco/pull/972), [#974](https://github.com/gfargo/coco/pull/974), [#975](https://github.com/gfargo/coco/pull/975)) but the marketing site still describes \`coco ui\` as "9 views" and doesn't mention \`coco issues\` / \`coco prs\` as top-level commands.

## Changes

**Toolbelt** (`src/app/_home/sections/Toolbelt.tsx`)
- Update the \`ui\` card description from "9 views" to "15 views" with the new view list
- Add \`coco issues\` and \`coco prs\` command cards with tagline, description, usage, and the most useful filter flags (\`--state\`, \`--mine\`, \`--json\`, \`--refresh\`, etc.)

**Workstation page** (`src/app/workstation/page.tsx`)
- Bump the OG description from "13 specialized views" to "15" and mention triage explicitly so the social card / SEO copy surfaces the feature
- Add \`Issues\` (gi) and \`PR Triage\` (gP) rows to the views grid + the chord-keys reference
- Tighten the existing \`Pull Request\` description to call out that it's the *current branch's* PR — distinguishes it from the new \`PR Triage\` row at a glance

## Validation

- [x] \`next build\` — compiles clean
- Lint failures in \`DocsContent.tsx\` are pre-existing config issues unrelated to this change (the lint config doesn't have the Next plugin registered, but the file uses a rule from it)

## Companion wiki update

The full deep-dive page for the triage feature lives in the wiki: [Issue & PR Triage](https://github.com/gfargo/coco/wiki/Issue-PR-Triage). Linked from Home / Coco-UI / TUI-Navigation / Command-Reference. The marketing copy intentionally keeps it brief and hands off to the wiki for keystroke-by-keystroke detail.