### PR TITLE
docs(workstation): submodules view + recursive submodule navigation (gfargo/coco#931)

### DIFF
--- a/src/app/_home/sections/WorkstationTeaser.tsx
+++ b/src/app/_home/sections/WorkstationTeaser.tsx
@@ -25,9 +25,9 @@ const features = [
   },
   {
     icon: LayoutGridIcon,
-    title: "12 specialized views",
+    title: "16 specialized views",
     description:
-      "History, status, diff, compose, branches, tags, stash, worktrees, pull-request, conflicts, reflog, and bisect.",
+      "History, status, diff, compose, branches, tags, stash, worktrees, pull-request, PR triage, issues, conflicts, reflog, bisect, submodules, and changelog. Drill into any submodule with Enter — every view re-scopes to it.",
   },
   {
     icon: LayersIcon,

--- a/src/app/workstation/page.tsx
+++ b/src/app/workstation/page.tsx
@@ -10,12 +10,14 @@ import {
     CodeIcon,
     DiffIcon,
     FileEditIcon,
+    FolderTreeIcon,
     GitBranchIcon,
     GitCompareIcon,
     GitPullRequestIcon,
     GitPullRequestArrowIcon,
     HistoryIcon,
     MonitorIcon,
+    PackageIcon,
     PenToolIcon,
     SearchIcon,
     TagIcon,
@@ -41,7 +43,7 @@ import { WorkflowsAccordion } from "./WorkflowsAccordion"
 export function generateMetadata(): Metadata {
   const title = "Workstation — Terminal Git Workstation"
   const description =
-    "A keyboard-driven terminal Git workstation with 15 specialized views — including GitHub issue and PR triage surfaces — chord navigation, AI-powered commits, one-keystroke PR creation, full-screen changelog generation, and customizable themes. No Electron, no mouse required."
+    "A keyboard-driven terminal Git workstation with 16 specialized views — including GitHub issue and PR triage surfaces and recursive submodule navigation — chord navigation, AI-powered commits, one-keystroke PR creation, full-screen changelog generation, and customizable themes. No Electron, no mouse required."
 
   return {
     title,
@@ -162,6 +164,12 @@ const tuiViews = [
     description: "Binary-search through history to find regressions — good / bad / skip / reset",
   },
   {
+    icon: PackageIcon,
+    name: "Submodules",
+    chord: ["g", "M"],
+    description: "Registered submodules with pinned sha, tracking branch, and clean / modified / uninitialized state. Enter drills into the cursored submodule.",
+  },
+  {
     icon: GitBranchIcon,
     name: "Changelog",
     chord: ["L"],
@@ -184,6 +192,7 @@ const chordKeys = [
   { key: "x", label: "Conflicts" },
   { key: "r", label: "Reflog" },
   { key: "B", label: "Bisect" },
+  { key: "M", label: "Submodules" },
   { key: "L", label: "Changelog" },
 ]
 
@@ -236,6 +245,13 @@ const crossViewWorkflows = [
     description:
       "From compose / status / diff, `E` opens the current commit draft in $EDITOR or $VISUAL. Round-trips through a temp file with `.md` extension for markdown highlighting. Companion to lowercase `e` (inline edit).",
   },
+  {
+    icon: FolderTreeIcon,
+    name: "Submodule drill-in",
+    chord: ["Enter"],
+    description:
+      "Press `Enter` on a submodule row (`g M`) or on a submodule file in a commit diff to drill in. Every view re-scopes to the submodule's working directory — like running `coco ui` from inside it. `Esc` or `<` walks back out; the title bar shows `coco › vendor/lib   ← esc` so you always know where you are. Frames stack.",
+  },
 ]
 
 const themePresets = [
@@ -265,7 +281,7 @@ const migrationFeatures = [
   "Terminal-native (no Electron)",
   "AI-powered commits & reviews",
   "Keyboard-first chord navigation",
-  "13 specialized views",
+  "16 specialized views",
   "PR workflows in terminal",
   "One-keystroke split / changelog / PR creation",
   "Theming + NO_COLOR",
@@ -292,7 +308,7 @@ export default function WorkstationPage() {
     applicationCategory: "DeveloperApplication",
     operatingSystem: "Linux, macOS, Windows",
     description:
-      "A keyboard-driven terminal Git workstation with 13 specialized views, chord navigation, AI-powered commits, one-keystroke PR creation, full-screen changelog generation, and customizable themes.",
+      "A keyboard-driven terminal Git workstation with 16 specialized views, recursive submodule navigation, chord navigation, AI-powered commits, one-keystroke PR creation, full-screen changelog generation, and customizable themes.",
     url: `${siteConfig.url}/workstation`,
     offers: {
       "@type": "Offer",
@@ -305,7 +321,7 @@ export default function WorkstationPage() {
       url: siteConfig.author.url,
     },
     featureList: [
-      "13 specialized TUI views",
+      "16 specialized TUI views",
       "Chord-based keyboard navigation",
       "Hunk-level staging",
       "AI-powered commit drafting",
@@ -396,7 +412,7 @@ export default function WorkstationPage() {
           <div className="container">
             <SectionHeader
               prompt="~/coco $ ui --view"
-              title="12 specialized views"
+              title="16 specialized views"
               subtitle="Each view is purpose-built for a specific Git workflow. Switch between them instantly with chord navigation."
             />
 


### PR DESCRIPTION
## Summary

The recursive submodule navigation work shipped in [gfargo/coco#931](https://github.com/gfargo/coco/issues/931) added a sixteenth top-level view (`g M`) and a brand-new drill-in interaction model. The website was still advertising "12–15 specialized views" depending on the page and didn't mention submodules anywhere.

## Changes

### Workstation page (`src/app/workstation/page.tsx`)

- View count bumped 12 → 16 across:
  - section header (`title="16 specialized views"`)
  - JSON-LD `description`, `featureList`
  - `metadata` `description`
  - `migrationFeatures` list
- New **Submodules** entry in the views grid (`g M` chord, `PackageIcon`, copy: registered submodules with pinned sha / tracking branch / clean / modified / uninitialized state, Enter drills in)
- New `M` chord in the keyboard chord-key list
- New **Submodule drill-in** entry in the cross-view workflows accordion (`FolderTreeIcon`, Enter chord, copy: drill into submodule from `g M` or commit diff, every view re-scopes to its working directory, Esc/`<` walks back out, frames stack, breadcrumb shows `coco › vendor/lib   ← esc`)

### Homepage teaser (`src/app/_home/sections/WorkstationTeaser.tsx`)

- View count bumped 12 → 16
- Description extended to include submodules + changelog views and the drill-in interaction

## Test plan

- [x] Icons exist in `lucide-react` (`FolderTreeIcon`, `PackageIcon`)
- [x] No syntax / typecheck errors specific to the touched files (pre-existing `eslint.config.mjs` typecheck noise unrelated to this change)
- [ ] Visual check after deploy — please confirm the views grid renders the new entry and the cross-view accordion shows the new workflow

Closes the marketing-site half of [gfargo/coco#931](https://github.com/gfargo/coco/issues/931).