### PR TITLE
fix(security): baseline security headers + harden new-tab links

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,7 +4,46 @@
  */
 await import("./src/env.mjs")
 
+/**
+ * Baseline security response headers, applied to every route.
+ *
+ * Scoped to zero-risk hardening for a static marketing site — clickjacking,
+ * MIME sniffing, referrer leakage, and powerful-feature access. HSTS is also
+ * pinned here (Vercel already sends a 2yr max-age; this adds includeSubDomains
+ * + preload). A full Content-Security-Policy is intentionally left out: the
+ * site loads Vercel Analytics / Speed Insights and uses styled-jsx + Next's
+ * inline bootstrap, so a correct CSP needs nonce wiring and live testing —
+ * tracked as a follow-up rather than shipped blind.
+ */
+const securityHeaders = [
+  // Disallow being framed by other origins (clickjacking).
+  { key: "X-Frame-Options", value: "SAMEORIGIN" },
+  // Don't let the browser MIME-sniff responses away from their declared type.
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  // Send only the origin on cross-origin navigations; full URL same-origin.
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  // No route needs these powerful features — deny them outright.
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=(), browsing-topics=()",
+  },
+  // Force HTTPS for the apex + subdomains, and allow preload-list inclusion.
+  {
+    key: "Strict-Transport-Security",
+    value: "max-age=63072000; includeSubDomains; preload",
+  },
+]
+
 /** @type {import("next").NextConfig} */
-const config = {}
+const config = {
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: securityHeaders,
+      },
+    ]
+  },
+}
 
 export default config

--- a/src/components/TrackedLink/index.tsx
+++ b/src/components/TrackedLink/index.tsx
@@ -28,8 +28,15 @@ export const TrackedLink = ({
     })
   }
 
+  // Harden links that open a new tab: prevent the opened page from
+  // reaching back through window.opener (reverse tabnabbing) and trim
+  // referrer leakage. Respect an explicit `rel` if the caller set one.
+  const rel =
+    (props.rel as string | undefined) ??
+    (props.target === "_blank" ? "noopener noreferrer" : undefined)
+
   return (
-    <Link className={className} {...props} onClick={handleClick}>
+    <Link className={className} {...props} rel={rel} onClick={handleClick}>
       {children}
     </Link>
   )


### PR DESCRIPTION
Preemptive security hardening spotted while reviewing the freshly-deployed site.

## Findings (live `coco.griffen.codes`)

The production response sent **only HSTS** — missing the common defense-in-depth headers — and several `target="_blank"` links lacked `rel="noopener noreferrer"`.

| Header | Before | After |
|---|---|---|
| X-Frame-Options | — | `SAMEORIGIN` (clickjacking) |
| X-Content-Type-Options | — | `nosniff` |
| Referrer-Policy | — | `strict-origin-when-cross-origin` |
| Permissions-Policy | — | `camera=(), microphone=(), geolocation=(), browsing-topics=()` |
| Strict-Transport-Security | `max-age=63072000` | `… ; includeSubDomains; preload` |

## Changes

- **`next.config.mjs`** — `headers()` applying the table above to `/:path*`.
- **`TrackedLink`** — auto-apply `rel="noopener noreferrer"` on `target="_blank"` (reverse-tabnabbing + referrer leakage), respecting an explicit caller `rel`.

## Deliberately deferred

A full **Content-Security-Policy** — the site loads Vercel Analytics / Speed Insights and uses styled-jsx + Next's inline bootstrap, so a correct CSP needs nonce wiring and live testing rather than a blind `'unsafe-inline'`. Noted in a config comment as a follow-up.

## Validation

- `yarn build` green (type-check + 26 routes).
- Verified against `next start`: all five headers emit; external `TrackedLink`s render the `rel`.