### PR TITLE
feat(site): feedback pass — lightbox fix, layout polish, interactive showcases

### DIFF
--- a/src/app/_home/sections/Install.tsx
+++ b/src/app/_home/sections/Install.tsx
@@ -1,22 +1,17 @@
 "use client"
 
 import { CopyCommand } from "@/components/CopyCommand"
+import { Lightbox } from "@/components/Lightbox"
 import { Section } from "@/components/Section"
 import { SectionHeader } from "@/components/SectionHeader"
+import Image from "next/image"
 
 const quickStartItems = [
-  {
-    command: "coco commit",
-    description: "AI-powered commit messages from your staged changes",
-  },
-  {
-    command: "coco changelog",
-    description: "Generate changelogs for any branch or range",
-  },
-  {
-    command: "coco review",
-    description: "Catch issues before you push",
-  },
+  { command: "coco commit", description: "AI commit messages from your staged changes" },
+  { command: "coco changelog", description: "Generate changelogs for any branch or range" },
+  { command: "coco review", description: "Catch issues before you push" },
+  { command: "coco ui", description: "The full workstation — every tool, one screen" },
+  { command: "coco init", description: "Setup wizard — pick a provider, set preferences" },
 ]
 
 export const InstallSection = () => {
@@ -29,44 +24,67 @@ export const InstallSection = () => {
           subtitle="Get up and running in seconds. One command installs and configures everything."
         />
 
-        {/* Prominent install command */}
-        <div className="mb-12 md:mb-16">
-          <CopyCommand command="npx git-coco@latest init" />
-        </div>
+        <div className="grid gap-10 lg:grid-cols-2 lg:items-center lg:gap-14">
+          {/* Left — install command + the toolbelt as a terminal session */}
+          <div>
+            <CopyCommand command="npx git-coco@latest init" />
 
-        {/* Quick-start flow */}
-        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-          {/* Fast path commands */}
-          {quickStartItems.map((item) => (
-            <div key={item.command} className="space-y-2">
-              <code className="inline-block rounded bg-[hsl(var(--code-bg))] px-3 py-1.5 font-mono text-sm text-terminal-green">
-                {item.command}
-              </code>
-              <p className="text-sm leading-6 text-muted-foreground">
-                {item.description}
-              </p>
+            <div className="mt-8 overflow-hidden rounded-lg border border-border bg-[hsl(var(--code-bg))]">
+              <div className="flex items-center gap-2 border-b border-border/40 bg-bg-elevated/60 px-4 py-2">
+                <span className="h-2.5 w-2.5 rounded-full bg-[#ff5f57]/80" />
+                <span className="h-2.5 w-2.5 rounded-full bg-[#febc2e]/80" />
+                <span className="h-2.5 w-2.5 rounded-full bg-[#28c840]/80" />
+                <span className="ml-2 font-mono text-[10px] text-muted-foreground/50">
+                  then run any of these
+                </span>
+              </div>
+              <ul className="divide-y divide-border/40">
+                {quickStartItems.map(({ command, description }) => (
+                  <li key={command} className="flex flex-col gap-1 px-4 py-3 sm:flex-row sm:items-baseline sm:gap-3">
+                    <code className="shrink-0 font-mono text-sm text-terminal-green">
+                      <span className="mr-1.5 text-muted-foreground/60">$</span>
+                      {command}
+                    </code>
+                    <span className="text-sm leading-6 text-muted-foreground">
+                      {description}
+                    </span>
+                  </li>
+                ))}
+              </ul>
             </div>
-          ))}
-
-          {/* Full experience */}
-          <div className="space-y-2">
-            <code className="inline-block rounded bg-[hsl(var(--code-bg))] px-3 py-1.5 font-mono text-sm text-terminal-green">
-              coco ui
-            </code>
-            <p className="text-sm leading-6 text-muted-foreground">
-              The full workstation — every tool in one keyboard-driven terminal
-              interface
-            </p>
           </div>
 
-          {/* Setup wizard */}
-          <div className="space-y-2">
-            <code className="inline-block rounded bg-[hsl(var(--code-bg))] px-3 py-1.5 font-mono text-sm text-terminal-green">
-              coco init
-            </code>
-            <p className="text-sm leading-6 text-muted-foreground">
-              First-time setup wizard — pick your AI provider, set your
-              preferences, and you&apos;re ready to go
+          {/* Right — a real `coco doctor` capture as visual proof */}
+          <div className="relative">
+            <div
+              aria-hidden="true"
+              className="pointer-events-none absolute -inset-6 -z-10 rounded-3xl bg-terminal-green/5 blur-3xl"
+            />
+            <div className="overflow-hidden rounded-xl border border-border/40 shadow-2xl shadow-black/40 ring-1 ring-black/20">
+              <div className="flex items-center gap-2 border-b border-border/30 bg-[hsl(150_20%_8%)] px-4 py-2.5">
+                <span className="h-2.5 w-2.5 rounded-full bg-[#ff5f57]/80" />
+                <span className="h-2.5 w-2.5 rounded-full bg-[#febc2e]/80" />
+                <span className="h-2.5 w-2.5 rounded-full bg-[#28c840]/80" />
+                <span className="ml-auto font-mono text-[10px] text-muted-foreground/40">
+                  coco doctor
+                </span>
+              </div>
+              <Lightbox
+                src="/screenshots/docs-doctor.png"
+                alt="coco doctor — environment and configuration checks"
+              >
+                <Image
+                  src="/screenshots/docs-doctor.png"
+                  alt="coco doctor — environment and configuration checks"
+                  width={1260}
+                  height={800}
+                  className="h-auto w-full object-cover object-top"
+                  sizes="(max-width: 1024px) 100vw, 560px"
+                />
+              </Lightbox>
+            </div>
+            <p className="mt-3 text-center font-mono text-xs text-muted-foreground">
+              coco doctor — verify your setup any time
             </p>
           </div>
         </div>

--- a/src/app/workstation/CrossViewShowcase.tsx
+++ b/src/app/workstation/CrossViewShowcase.tsx
@@ -1,0 +1,193 @@
+"use client"
+
+import { useRef, useState } from "react"
+import Image from "next/image"
+import {
+  FileEditIcon,
+  FolderTreeIcon,
+  GitBranchIcon,
+  GitCompareIcon,
+  GitPullRequestIcon,
+  SearchIcon,
+  type LucideIcon,
+} from "lucide-react"
+
+import { KbdBadge } from "@/components/KbdBadge"
+import { Lightbox } from "@/components/Lightbox"
+import { cn } from "@/lib/utils"
+
+interface Workflow {
+  icon: LucideIcon
+  name: string
+  chord: string[]
+  description: string
+  screenshot: string
+}
+
+// Cross-view flows: a key on one surface acts on a second view. Each is
+// paired with the most representative capture of where it lands. (Split
+// and create-PR render AI-generated overlays that can't be captured
+// deterministically, so they point at the surface they're driven from.)
+const WORKFLOWS: Workflow[] = [
+  {
+    icon: GitCompareIcon,
+    name: "Compare two refs",
+    chord: ["m"],
+    description:
+      "Mark a ref on branches / tags / history with m, then Enter on a second ref to open git diff base..head. Cleared automatically when the diff is popped.",
+    screenshot: "/screenshots/view-diff.png",
+  },
+  {
+    icon: GitPullRequestIcon,
+    name: "Create a pull request",
+    chord: ["C"],
+    description:
+      "From history or branches, C generates a PR title + body from coco changelog against the default branch, then opens a multi-line review prompt. Auto-detects head + base; surfaces a pointer if a PR is already open.",
+    screenshot: "/screenshots/view-pull-request.png",
+  },
+  {
+    icon: GitBranchIcon,
+    name: "Generate a changelog",
+    chord: ["L"],
+    description:
+      "From history or branches, L opens a full-screen changelog view. Per-branch cache for instant re-entry; r regenerates, y yanks to clipboard, E opens in $EDITOR, c kicks off create-PR seeded with this content.",
+    screenshot: "/screenshots/view-changelog.png",
+  },
+  {
+    icon: FileEditIcon,
+    name: "Split commits",
+    chord: ["S"],
+    description:
+      "From compose, S opens an overlay with an LLM-generated multi-commit plan. Each group's title respects your conventional-commits + commitlint config. y apply / r regenerate / < cancel.",
+    screenshot: "/screenshots/view-compose.png",
+  },
+  {
+    icon: SearchIcon,
+    name: "Bisect (in-view actions)",
+    chord: ["g", "b", "s", "x"],
+    description:
+      "Inside the bisect view: g good · b bad · s skip · x reset. The title bar shows a BISECTING badge whenever a bisect is in progress.",
+    screenshot: "/screenshots/view-bisect.png",
+  },
+  {
+    icon: FolderTreeIcon,
+    name: "Submodule drill-in",
+    chord: ["Enter"],
+    description:
+      "Press Enter on a submodule row (g M) or a submodule file in a diff to drill in. Every view re-scopes to the submodule's working directory — like running coco ui from inside it. Esc or < walks back out; frames stack.",
+    screenshot: "/screenshots/view-submodules.png",
+  },
+]
+
+/**
+ * Interactive showcase for the cross-view workflows. A selectable list on
+ * the left drives one large, sticky terminal preview on the right — hover,
+ * click, or arrow-key through the flows and the screen swaps with a
+ * crossfade. Replaces the static card grid so each multi-step flow gets a
+ * real picture of where it lands.
+ */
+export function CrossViewShowcase() {
+  const [active, setActive] = useState(0)
+  const listRef = useRef<HTMLDivElement>(null)
+  const flow = WORKFLOWS[active]!
+
+  function onKeyDown(e: React.KeyboardEvent) {
+    if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return
+    e.preventDefault()
+    const next =
+      e.key === "ArrowDown"
+        ? (active + 1) % WORKFLOWS.length
+        : (active - 1 + WORKFLOWS.length) % WORKFLOWS.length
+    setActive(next)
+    listRef.current
+      ?.querySelectorAll<HTMLButtonElement>("[data-flow-row]")
+      [next]?.focus()
+  }
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[minmax(0,5fr)_minmax(0,7fr)] lg:gap-10">
+      {/* Selectable flow list */}
+      <div
+        ref={listRef}
+        role="tablist"
+        aria-label="Cross-view workflows"
+        onKeyDown={onKeyDown}
+        className="order-2 rounded-lg border border-border bg-[hsl(var(--code-bg))] p-1.5 lg:order-1"
+      >
+        {WORKFLOWS.map((w, i) => {
+          const Icon = w.icon
+          const selected = i === active
+          return (
+            <button
+              key={w.name}
+              data-flow-row
+              role="tab"
+              aria-selected={selected}
+              tabIndex={selected ? 0 : -1}
+              onMouseEnter={() => setActive(i)}
+              onFocus={() => setActive(i)}
+              onClick={() => setActive(i)}
+              className={cn(
+                "flex w-full items-center gap-3 rounded-md border-l-2 px-3 py-2.5 text-left font-mono text-sm transition-colors",
+                selected
+                  ? "border-terminal-green bg-terminal-green/10 text-foreground"
+                  : "border-transparent text-muted-foreground hover:bg-bg-elevated/60 hover:text-foreground"
+              )}
+            >
+              <Icon
+                className={cn(
+                  "h-4 w-4 shrink-0",
+                  selected ? "text-terminal-green" : "text-muted-foreground"
+                )}
+              />
+              <span className="flex-1 truncate">{w.name}</span>
+              <KbdBadge keys={w.chord} />
+            </button>
+          )
+        })}
+      </div>
+
+      {/* Sticky preview */}
+      <div className="order-1 lg:order-2 lg:sticky lg:top-24 lg:self-start">
+        <div className="overflow-hidden rounded-xl border border-border/60 shadow-2xl shadow-black/40 ring-1 ring-black/20">
+          <div className="flex items-center gap-2 border-b border-border/40 bg-[hsl(150_20%_8%)] px-4 py-2.5">
+            <span className="h-2.5 w-2.5 rounded-full bg-[#ff5f57]/80" />
+            <span className="h-2.5 w-2.5 rounded-full bg-[#febc2e]/80" />
+            <span className="h-2.5 w-2.5 rounded-full bg-[#28c840]/80" />
+            <span className="ml-3 font-mono text-[10px] text-muted-foreground/50">
+              coco ui — {flow.name.toLowerCase()}
+            </span>
+            <span className="ml-auto font-mono text-[10px] text-muted-foreground/40">
+              {flow.chord.join(" ")}
+            </span>
+          </div>
+          <Lightbox src={flow.screenshot} alt={`${flow.name} — coco ui`}>
+            <div className="bg-[hsl(var(--code-bg))]">
+              <Image
+                key={flow.screenshot}
+                src={flow.screenshot}
+                alt={`${flow.name} — coco ui`}
+                width={1260}
+                height={800}
+                priority={active === 0}
+                className="h-auto w-full animate-fade-in-up object-cover object-top"
+                sizes="(max-width: 1024px) 100vw, 640px"
+              />
+            </div>
+          </Lightbox>
+        </div>
+
+        <div className="mt-4 flex items-start gap-3 px-1">
+          <flow.icon className="mt-0.5 h-4 w-4 shrink-0 text-terminal-green" />
+          <div>
+            <h3 className="font-mono text-sm font-semibold text-foreground">{flow.name}</h3>
+            <p className="mt-1 text-sm leading-relaxed text-muted-foreground">{flow.description}</p>
+          </div>
+        </div>
+        <p className="mt-3 px-1 font-mono text-[11px] text-muted-foreground/50">
+          ↑ ↓ to explore · click to enlarge
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/app/workstation/page.tsx
+++ b/src/app/workstation/page.tsx
@@ -4,13 +4,7 @@ import {
   BookOpenIcon,
   ChevronRightIcon,
   CodeIcon,
-  FileEditIcon,
-  FolderTreeIcon,
-  GitBranchIcon,
-  GitCompareIcon,
-  GitPullRequestIcon,
   MonitorIcon,
-  SearchIcon,
 } from "lucide-react"
 
 import { Header } from "@/components/Header"
@@ -18,13 +12,13 @@ import { Footer } from "@/components/Footer"
 import { Section } from "@/components/Section"
 import { SectionHeader } from "@/components/SectionHeader"
 import { TerminalAtmosphere } from "@/components/TerminalAtmosphere"
-import { KbdBadge } from "@/components/KbdBadge"
 import { CopyCommand } from "@/components/CopyCommand"
 import { TrackedLink } from "@/components/TrackedLink"
 import { ThemeWall } from "@/components/ThemeWall"
 import { siteConfig } from "@/config/site"
 import { WorkflowsAccordion } from "./WorkflowsAccordion"
 import { GifHero } from "./GifHero"
+import { CrossViewShowcase } from "./CrossViewShowcase"
 import { ViewExplorer } from "./ViewExplorer"
 import { GifDemo } from "@/components/GifDemo"
 
@@ -87,64 +81,6 @@ const chordKeys = [
   { key: "B", label: "Bisect" },
   { key: "M", label: "Submodules" },
   { key: "L", label: "Changelog" },
-]
-
-/**
- * Cross-view workflows that span multiple views (#779, #784).
- * Surfaced as a distinct section because the keys are scoped to the
- * source view but the action lands on a *second* view — they're not
- * top-level destinations like the entries above.
- */
-const crossViewWorkflows = [
-  {
-    icon: GitCompareIcon,
-    name: "Compare two refs",
-    chord: ["m"],
-    description:
-      "Mark a ref on branches / tags / history with `m`, then `Enter` on a second ref to open `git diff base..head`. Cleared automatically when the diff is popped.",
-  },
-  {
-    icon: SearchIcon,
-    name: "Bisect (in-view actions)",
-    chord: ["g", "b", "s", "x"],
-    description:
-      "Inside the bisect view: `g` good · `b` bad · `s` skip · `x` reset. The title bar shows a BISECTING badge whenever a bisect is in progress.",
-  },
-  {
-    icon: GitPullRequestIcon,
-    name: "Create a pull request",
-    chord: ["C"],
-    description:
-      "From history or branches, `C` generates a PR title + body from `coco changelog` against the default branch, then opens a multi-line review prompt. Auto-detects head + base; surfaces a pointer if a PR is already open.",
-  },
-  {
-    icon: GitBranchIcon,
-    name: "Generate a changelog",
-    chord: ["L"],
-    description:
-      "From history or branches, `L` opens a full-screen changelog view. Per-branch cache for instant re-entry; `r` regenerates, `y` yanks to clipboard, `E` opens in $EDITOR, `c` kicks off create-PR seeded with this content.",
-  },
-  {
-    icon: FileEditIcon,
-    name: "Split commits",
-    chord: ["S"],
-    description:
-      "From compose, `S` opens an overlay with an LLM-generated multi-commit plan. Each group's title respects your conventional-commits + commitlint config. `y` apply / `r` regenerate / `<` cancel.",
-  },
-  {
-    icon: FileEditIcon,
-    name: "Edit in $EDITOR",
-    chord: ["E"],
-    description:
-      "From compose / status / diff, `E` opens the current commit draft in $EDITOR or $VISUAL. Round-trips through a temp file with `.md` extension for markdown highlighting. Companion to lowercase `e` (inline edit).",
-  },
-  {
-    icon: FolderTreeIcon,
-    name: "Submodule drill-in",
-    chord: ["Enter"],
-    description:
-      "Press `Enter` on a submodule row (`g M`) or on a submodule file in a commit diff to drill in. Every view re-scopes to the submodule's working directory — like running `coco ui` from inside it. `Esc` or `<` walks back out; the title bar shows `coco › vendor/lib   ← esc` so you always know where you are. Frames stack.",
-  },
 ]
 
 /**
@@ -420,27 +356,7 @@ export default function WorkstationPage() {
               subtitle="Some flows span multiple views — mark a state on one surface, act on it from another. Footer hints adapt so the override is always discoverable."
             />
 
-            <div className="mx-auto grid max-w-3xl grid-cols-1 gap-4 md:grid-cols-2">
-              {crossViewWorkflows.map(({ icon: Icon, name, chord, description }) => (
-                <div
-                  key={name}
-                  className="group rounded-lg border border-border bg-bg-surface/30 p-5 transition-colors hover:border-terminal-green/30 hover:bg-bg-elevated"
-                >
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-border bg-bg-elevated">
-                      <Icon className="h-4 w-4 text-terminal-green" />
-                    </div>
-                    <KbdBadge keys={chord} />
-                  </div>
-                  <h3 className="mt-3 font-mono text-sm font-semibold text-foreground">
-                    {name}
-                  </h3>
-                  <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">
-                    {description}
-                  </p>
-                </div>
-              ))}
-            </div>
+            <CrossViewShowcase />
           </div>
         </Section>
 

--- a/src/app/workstation/page.tsx
+++ b/src/app/workstation/page.tsx
@@ -147,23 +147,43 @@ const crossViewWorkflows = [
   },
 ]
 
-const migrationFeatures = [
-  "Terminal-native (no Electron)",
-  "AI-powered commits & reviews",
-  "Keyboard-first chord navigation",
-  "16 specialized views",
-  "PR workflows in terminal",
-  "One-keystroke split / changelog / PR creation",
-  "Theming + NO_COLOR",
-  "Free & open source",
+/**
+ * Feature comparison across popular Git clients. `coco` is highlighted.
+ * Competitor values are a fair-faith snapshot — partial (`~`) covers
+ * "possible but not first-class". Keyed by client so a row can never
+ * silently drift out of sync with the column count.
+ */
+type Support = "yes" | "partial" | "no"
+
+const comparisonClients = [
+  { key: "coco", name: "coco ui", highlight: true },
+  { key: "gitkraken", name: "GitKraken", highlight: false },
+  { key: "lazygit", name: "lazygit", highlight: false },
+  { key: "gitui", name: "gitui", highlight: false },
+  { key: "tig", name: "tig", highlight: false },
+] as const
+
+type ClientKey = (typeof comparisonClients)[number]["key"]
+
+const comparisonRows: Array<{ feature: string } & Record<ClientKey, Support>> = [
+  { feature: "Terminal-native (no Electron)", coco: "yes", gitkraken: "no", lazygit: "yes", gitui: "yes", tig: "yes" },
+  { feature: "Keyboard-first navigation", coco: "yes", gitkraken: "partial", lazygit: "yes", gitui: "yes", tig: "yes" },
+  { feature: "Hunk-level staging", coco: "yes", gitkraken: "yes", lazygit: "yes", gitui: "yes", tig: "no" },
+  { feature: "AI commit messages", coco: "yes", gitkraken: "partial", lazygit: "no", gitui: "no", tig: "no" },
+  { feature: "AI code review", coco: "yes", gitkraken: "no", lazygit: "no", gitui: "no", tig: "no" },
+  { feature: "AI changelog generation", coco: "yes", gitkraken: "no", lazygit: "no", gitui: "no", tig: "no" },
+  { feature: "AI commit splitting", coco: "yes", gitkraken: "no", lazygit: "partial", gitui: "no", tig: "no" },
+  { feature: "Multi-provider / local AI", coco: "yes", gitkraken: "no", lazygit: "no", gitui: "no", tig: "no" },
+  { feature: "One-keystroke PR creation", coco: "yes", gitkraken: "yes", lazygit: "no", gitui: "no", tig: "no" },
+  { feature: "GitHub issue / PR triage", coco: "yes", gitkraken: "yes", lazygit: "no", gitui: "no", tig: "no" },
+  { feature: "Conflict resolution helper", coco: "yes", gitkraken: "yes", lazygit: "partial", gitui: "partial", tig: "no" },
+  { feature: "Bisect & reflog recovery", coco: "yes", gitkraken: "partial", lazygit: "partial", gitui: "no", tig: "partial" },
+  { feature: "Recursive submodule drill-in", coco: "yes", gitkraken: "partial", lazygit: "partial", gitui: "no", tig: "no" },
+  { feature: "Theming + NO_COLOR", coco: "yes", gitkraken: "partial", lazygit: "partial", gitui: "partial", tig: "partial" },
+  { feature: "Free & open source", coco: "yes", gitkraken: "no", lazygit: "yes", gitui: "yes", tig: "yes" },
 ]
 
-const competitors = [
-  { name: "GitKraken", values: ["✗", "✗", "✗", "~", "✓", "✗", "✗"] },
-  { name: "lazygit", values: ["✓", "✗", "~", "~", "✗", "✓", "✓"] },
-  { name: "gitui", values: ["✓", "✗", "✗", "~", "✗", "✓", "✓"] },
-  { name: "coco ui", values: ["✓", "✓", "✓", "✓", "✓", "✓", "✓"] },
-]
+const supportGlyph: Record<Support, string> = { yes: "✓", partial: "~", no: "✗" }
 
 /* ------------------------------------------------------------------ */
 /*  Page Component (Server Component)                                  */
@@ -226,50 +246,70 @@ export default function WorkstationPage() {
         {/* ============================================================ */}
         {/*  HERO                                                        */}
         {/* ============================================================ */}
-        {/* ============================================================ */}
-        {/*  HERO                                                        */}
-        {/* ============================================================ */}
-        <Section id="workstation-hero" className="relative overflow-hidden pt-8 pb-0 md:pt-12 lg:pt-16">
+        <Section id="workstation-hero" className="relative overflow-hidden pt-10 pb-12 md:pt-16 md:pb-20">
           <TerminalAtmosphere variant="hero" />
 
           <div className="container relative z-10">
-            {/* Tight header — title + CTA on one line */}
-            <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-              <div>
+            <div className="grid items-center gap-10 lg:grid-cols-[5fr_7fr] lg:gap-14">
+              {/* Left — copy + CTA + stats */}
+              <div className="flex flex-col items-start">
                 <span className="font-mono text-xs tracking-widest uppercase text-terminal-green/70">
                   coco workstation
                 </span>
-                <h1 className="mt-1 font-mono text-2xl font-bold tracking-tight text-foreground sm:text-3xl md:text-4xl">
+                <h1 className="mt-2 font-mono text-3xl font-bold tracking-tight text-foreground sm:text-4xl md:text-5xl">
                   Git, keyboard-first
                   <span
                     className="ml-1 inline-block h-[0.8em] w-[0.45ch] translate-y-[0.05em] bg-terminal-green animate-cursor-blink"
                     aria-hidden="true"
                   />
                 </h1>
-              </div>
-              <CopyCommand command="npx git-coco@latest ui" />
-            </div>
-          </div>
+                <p className="mt-4 max-w-md text-base leading-7 text-muted-foreground">
+                  One terminal surface for every Git workflow — 16 views, chord
+                  navigation, AI commits, and PR triage. No Electron, no mouse.
+                </p>
 
-          {/* Full-bleed GIF — breaks out of container, edge to edge */}
-          <div className="relative mt-2">
-            {/* Subtle glow behind */}
-            <div className="absolute inset-x-0 top-0 h-32 bg-gradient-to-b from-terminal-green/5 to-transparent pointer-events-none" />
-
-            <div className="mx-auto max-w-[1600px] px-2 sm:px-4">
-              <div className="overflow-hidden rounded-t-xl border border-b-0 border-border/40 shadow-2xl shadow-black/60">
-                {/* Minimal title bar */}
-                <div className="flex items-center gap-2 bg-[hsl(150_20%_8%)] px-4 py-2 border-b border-border/30">
-                  <span className="h-2.5 w-2.5 rounded-full bg-[#ff5f57]/80" />
-                  <span className="h-2.5 w-2.5 rounded-full bg-[#febc2e]/80" />
-                  <span className="h-2.5 w-2.5 rounded-full bg-[#28c840]/80" />
-                  <span className="ml-auto font-mono text-[10px] text-muted-foreground/40">
-                    workspace → repo → history
-                  </span>
+                <div className="mt-6">
+                  <CopyCommand command="npx git-coco@latest ui" />
                 </div>
 
-                {/* The GIF */}
-                <GifHero />
+                {/* Quick stats */}
+                <dl className="mt-8 grid w-full max-w-md grid-cols-4 gap-3 border-t border-border/60 pt-6">
+                  {[
+                    { value: "16", label: "views" },
+                    { value: "31", label: "themes" },
+                    { value: "<100ms", label: "boot" },
+                    { value: "0", label: "mouse" },
+                  ].map(({ value, label }) => (
+                    <div key={label} className="flex flex-col">
+                      <dt className="font-mono text-lg font-bold text-terminal-green sm:text-xl">
+                        {value}
+                      </dt>
+                      <dd className="font-mono text-[11px] uppercase tracking-wider text-muted-foreground">
+                        {label}
+                      </dd>
+                    </div>
+                  ))}
+                </dl>
+              </div>
+
+              {/* Right — framed, contained demo */}
+              <div className="relative">
+                <div
+                  aria-hidden="true"
+                  className="pointer-events-none absolute -inset-6 -z-10 rounded-3xl bg-terminal-green/5 blur-3xl"
+                />
+                <div className="overflow-hidden rounded-xl border border-border/40 shadow-2xl shadow-black/50 ring-1 ring-black/20">
+                  {/* Minimal title bar */}
+                  <div className="flex items-center gap-2 border-b border-border/30 bg-[hsl(150_20%_8%)] px-4 py-2.5">
+                    <span className="h-2.5 w-2.5 rounded-full bg-[#ff5f57]/80" />
+                    <span className="h-2.5 w-2.5 rounded-full bg-[#febc2e]/80" />
+                    <span className="h-2.5 w-2.5 rounded-full bg-[#28c840]/80" />
+                    <span className="ml-auto font-mono text-[10px] text-muted-foreground/40">
+                      workspace → repo → history
+                    </span>
+                  </div>
+                  <GifHero />
+                </div>
               </div>
             </div>
           </div>
@@ -322,9 +362,11 @@ export default function WorkstationPage() {
               subtitle="Press g to enter navigation mode, then a second key to jump to any view. Muscle memory replaces mouse clicks."
             />
 
-            <div className="mx-auto max-w-2xl">
+            {/* Reference + live demo, side by side */}
+            <div className="grid gap-8 lg:grid-cols-2 lg:items-start lg:gap-12">
+              {/* Left — chord key reference */}
               <div className="rounded-lg border border-border bg-[hsl(var(--code-bg))] p-6 sm:p-8">
-                <div className="mb-6 flex items-center justify-center gap-3">
+                <div className="mb-6 flex items-center gap-3">
                   <kbd className="inline-flex h-10 w-10 items-center justify-center rounded-md border border-terminal-green/40 bg-bg-elevated font-mono text-lg text-terminal-green">
                     g
                   </kbd>
@@ -346,7 +388,7 @@ export default function WorkstationPage() {
                   ))}
                 </div>
 
-                <p className="mt-6 text-center text-xs text-muted-foreground">
+                <p className="mt-6 text-xs text-muted-foreground">
                   Press{" "}
                   <kbd className="rounded border border-border bg-bg-elevated px-1 font-mono text-[10px]">
                     ?
@@ -354,15 +396,15 @@ export default function WorkstationPage() {
                   anywhere for the full keymap reference
                 </p>
               </div>
-            </div>
 
-            {/* View-switching GIF demo */}
-            <div className="mt-10">
-              <GifDemo
-                src="/screenshots/demo-ui-view-switching.gif"
-                alt="Chord navigation in action — switching between history, status, branches, and diff"
-                caption="g + key — instant view switching without leaving the keyboard"
-              />
+              {/* Right — chord navigation in action */}
+              <div className="lg:sticky lg:top-24">
+                <GifDemo
+                  src="/screenshots/demo-ui-view-switching.gif"
+                  alt="Chord navigation in action — switching between history, status, branches, and diff"
+                  caption="g + key — instant view switching without leaving the keyboard"
+                />
+              </div>
             </div>
           </div>
         </Section>
@@ -481,18 +523,18 @@ export default function WorkstationPage() {
             />
 
             <div className="sm:max-w-4xl sm:mx-auto overflow-x-auto">
-              <table className="w-full min-w-[600px] border-collapse font-mono text-sm">
+              <table className="w-full min-w-[640px] border-collapse font-mono text-sm">
                 <thead>
                   <tr className="border-b border-border">
                     <th className="py-3 pr-4 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground">
                       Feature
                     </th>
-                    {competitors.map(({ name }) => (
+                    {comparisonClients.map(({ key, name, highlight }) => (
                       <th
-                        key={name}
+                        key={key}
                         className={`px-3 py-3 text-center text-xs font-medium uppercase tracking-wider ${
-                          name === "coco ui"
-                            ? "text-terminal-green"
+                          highlight
+                            ? "rounded-t-md bg-terminal-green/10 text-terminal-green"
                             : "text-muted-foreground"
                         }`}
                       >
@@ -502,29 +544,40 @@ export default function WorkstationPage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {migrationFeatures.map((feature, i) => (
-                    <tr key={feature} className="border-b border-border/50 last:border-0">
-                      <td className="py-3 pr-4 text-foreground/80">{feature}</td>
-                      {competitors.map(({ name, values }) => (
-                        <td
-                          key={name}
-                          className={`px-3 py-3 text-center ${
-                            values[i] === "✓"
-                              ? name === "coco ui"
-                                ? "text-terminal-green"
-                                : "text-foreground/70"
-                              : values[i] === "~"
-                                ? "text-muted-foreground"
-                                : "text-muted-foreground/50"
-                          }`}
-                        >
-                          {values[i]}
-                        </td>
-                      ))}
+                  {comparisonRows.map((row) => (
+                    <tr key={row.feature} className="border-b border-border/50 last:border-0">
+                      <td className="py-3 pr-4 text-foreground/80">{row.feature}</td>
+                      {comparisonClients.map(({ key, highlight }) => {
+                        const support = row[key]
+                        return (
+                          <td
+                            key={key}
+                            className={`px-3 py-3 text-center ${highlight ? "bg-terminal-green/5" : ""} ${
+                              support === "yes"
+                                ? highlight
+                                  ? "text-terminal-green"
+                                  : "text-foreground/70"
+                                : support === "partial"
+                                  ? "text-muted-foreground"
+                                  : "text-muted-foreground/40"
+                            }`}
+                          >
+                            {supportGlyph[support]}
+                          </td>
+                        )
+                      })}
                     </tr>
                   ))}
                 </tbody>
               </table>
+            </div>
+
+            {/* Legend */}
+            <div className="mt-5 flex flex-wrap items-center justify-center gap-x-6 gap-y-2 font-mono text-xs text-muted-foreground">
+              <span><span className="text-terminal-green">✓</span> first-class</span>
+              <span><span className="text-muted-foreground">~</span> partial / possible</span>
+              <span><span className="text-muted-foreground/40">✗</span> not available</span>
+              <span className="text-muted-foreground/50">Comparison is a fair-faith snapshot; corrections welcome.</span>
             </div>
           </div>
         </Section>

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -4,7 +4,9 @@ import {
     PackageIcon,
     TerminalIcon
 } from "lucide-react"
+import Image from "next/image"
 import Link from "next/link"
+import cocoCover from "@/assets/coco-cover.png"
 import { siteConfig } from "@/config/site"
 
 const productLinks = [
@@ -98,6 +100,20 @@ export const Footer: React.FC = () => {
             <p className="text-sm leading-relaxed text-muted-foreground">
               AI-powered Git tools for developers who live in the terminal.
             </p>
+            {/* The original coco cover illustration — kept as a wink in the
+                footer now that the hero shows the real workstation. */}
+            <Link
+              href="/"
+              aria-label="coco home"
+              className="group mt-1 block overflow-hidden rounded-lg border border-border/60 transition-colors hover:border-terminal-green/40"
+            >
+              <Image
+                src={cocoCover}
+                alt="coco — AI-powered git assistant"
+                className="h-auto w-full opacity-90 transition-opacity group-hover:opacity-100"
+                sizes="(max-width: 640px) 100vw, 280px"
+              />
+            </Link>
           </div>
 
           {/* Product */}

--- a/src/components/Lightbox/index.tsx
+++ b/src/components/Lightbox/index.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useCallback, useEffect, useState } from "react"
+import { createPortal } from "react-dom"
 import Image from "next/image"
 import { XIcon } from "lucide-react"
 import { cn } from "@/lib/utils"
@@ -10,17 +11,36 @@ interface LightboxProps {
   alt: string
   children: React.ReactNode
   className?: string
+  /** Notified whenever the overlay opens or closes. */
+  onOpenChange?: (open: boolean) => void
 }
 
 /**
  * Wraps any clickable element (typically a screenshot) and opens a
  * full-viewport lightbox overlay on click. Press Escape or click the
  * backdrop to close.
+ *
+ * The overlay is rendered through a portal on `document.body` — not in
+ * place — so it escapes any ancestor with `overflow: hidden` or a CSS
+ * `transform` (e.g. the marquee rows in ThemeWall, whose animated
+ * transform would otherwise become the containing block for the
+ * fixed-position overlay and clip it).
  */
-export function Lightbox({ src, alt, children, className }: LightboxProps) {
+export function Lightbox({ src, alt, children, className, onOpenChange }: LightboxProps) {
   const [open, setOpen] = useState(false)
+  const [mounted, setMounted] = useState(false)
 
-  const close = useCallback(() => setOpen(false), [])
+  useEffect(() => setMounted(true), [])
+
+  const setOpenState = useCallback(
+    (next: boolean) => {
+      setOpen(next)
+      onOpenChange?.(next)
+    },
+    [onOpenChange]
+  )
+
+  const close = useCallback(() => setOpenState(false), [setOpenState])
 
   useEffect(() => {
     if (!open) return
@@ -35,64 +55,74 @@ export function Lightbox({ src, alt, children, className }: LightboxProps) {
     }
   }, [open, close])
 
+  const overlay =
+    open && mounted
+      ? createPortal(
+          <div
+            className="fixed inset-0 z-[100] flex items-center justify-center p-4 sm:p-6 bg-black/95 backdrop-blur-md"
+            onClick={close}
+            role="dialog"
+            aria-modal="true"
+            aria-label={alt}
+            style={{ animation: "fadeIn 150ms ease-out" }}
+          >
+            {/* Close button */}
+            <button
+              onClick={close}
+              className="absolute right-4 top-4 z-10 flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/5 text-white/80 transition-all hover:bg-white/10 hover:text-white hover:scale-110"
+              aria-label="Close lightbox"
+            >
+              <XIcon className="h-5 w-5" />
+            </button>
+
+            {/* Hint text */}
+            <span className="absolute bottom-4 left-1/2 -translate-x-1/2 font-mono text-xs text-white/40">
+              esc to close
+            </span>
+
+            {/* Image — fills as much of the viewport as possible */}
+            <div
+              className="relative flex h-full w-full items-center justify-center"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <Image
+                src={src}
+                alt={alt}
+                width={2520}
+                height={1600}
+                className="max-h-[85vh] max-w-[92vw] w-auto h-auto rounded-md object-contain shadow-2xl shadow-black/80 border border-white/5"
+                priority
+                quality={95}
+              />
+            </div>
+
+            <style jsx global>{`
+              @keyframes fadeIn {
+                from {
+                  opacity: 0;
+                }
+                to {
+                  opacity: 1;
+                }
+              }
+            `}</style>
+          </div>,
+          document.body
+        )
+      : null
+
   return (
     <>
       <button
         type="button"
-        onClick={() => setOpen(true)}
+        onClick={() => setOpenState(true)}
         className={cn("cursor-zoom-in w-full text-left", className)}
         aria-label={`View ${alt} full size`}
       >
         {children}
       </button>
 
-      {open && (
-        <div
-          className="fixed inset-0 z-[100] flex items-center justify-center p-4 sm:p-6 bg-black/95 backdrop-blur-md"
-          onClick={close}
-          role="dialog"
-          aria-modal="true"
-          aria-label={alt}
-          style={{ animation: "fadeIn 150ms ease-out" }}
-        >
-          {/* Close button */}
-          <button
-            onClick={close}
-            className="absolute right-4 top-4 z-10 flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/5 text-white/80 transition-all hover:bg-white/10 hover:text-white hover:scale-110"
-            aria-label="Close lightbox"
-          >
-            <XIcon className="h-5 w-5" />
-          </button>
-
-          {/* Hint text */}
-          <span className="absolute bottom-4 left-1/2 -translate-x-1/2 font-mono text-xs text-white/40">
-            esc to close
-          </span>
-
-          {/* Image — fills as much of the viewport as possible */}
-          <div
-            className="relative w-full h-full flex items-center justify-center"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <Image
-              src={src}
-              alt={alt}
-              width={2520}
-              height={1600}
-              className="max-h-[85vh] max-w-[92vw] w-auto h-auto rounded-md object-contain shadow-2xl shadow-black/80 border border-white/5"
-              priority
-              quality={95}
-            />
-          </div>
-        </div>
-      )}
-
-      <style jsx global>{`
-        @keyframes fadeIn {
-          from { opacity: 0; }
-          to { opacity: 1; }
-        }
-      `}</style>
+      {overlay}
     </>
   )
 }

--- a/src/components/ThemeWall/index.tsx
+++ b/src/components/ThemeWall/index.tsx
@@ -64,14 +64,16 @@ function Tile({
   theme,
   onHover,
   active,
+  onLightbox,
 }: {
   theme: ThemeTile
   onHover: (t: ThemeTile | null) => void
   active: boolean
+  onLightbox: (open: boolean) => void
 }) {
   const src = `/screenshots/theme-${theme.slug}.png`
   return (
-    <Lightbox src={src} alt={`coco ui — ${theme.name} theme`}>
+    <Lightbox src={src} alt={`coco ui — ${theme.name} theme`} onOpenChange={onLightbox}>
       <figure
         onMouseEnter={() => onHover(theme)}
         onMouseLeave={() => onHover(null)}
@@ -113,17 +115,30 @@ interface MarqueeRowProps {
   reverse?: boolean
   onHover: (t: ThemeTile | null) => void
   activeSlug: string | null
+  paused: boolean
+  onLightbox: (open: boolean) => void
 }
 
-function MarqueeRow({ themes, duration, reverse, onHover, activeSlug }: MarqueeRowProps) {
+function MarqueeRow({ themes, duration, reverse, onHover, activeSlug, paused, onLightbox }: MarqueeRowProps) {
   // Duplicate the row so the translateX loop is seamless.
   const doubled = [...themes, ...themes]
   return (
     <div className="group/row relative flex overflow-hidden">
       <div
-        className="flex shrink-0 gap-4 pr-4 group-hover/row:[animation-play-state:paused]"
+        className={cn(
+          "flex shrink-0 gap-4 pr-4 group-hover/row:[animation-play-state:paused]",
+          // Freeze every row while the lightbox is open so the zoomed
+          // tile isn't yanked out from under the cursor.
+          paused && "[animation-play-state:paused]"
+        )}
+        // Use the animation *longhands* (not the `animation` shorthand) so we
+        // never set animation-play-state inline — otherwise the inline value
+        // would beat the hover/paused utility classes and they'd never apply.
         style={{
-          animation: `theme-marquee ${duration}s linear infinite`,
+          animationName: "theme-marquee",
+          animationDuration: `${duration}s`,
+          animationTimingFunction: "linear",
+          animationIterationCount: "infinite",
           animationDirection: reverse ? "reverse" : "normal",
         }}
       >
@@ -133,6 +148,7 @@ function MarqueeRow({ themes, duration, reverse, onHover, activeSlug }: MarqueeR
             theme={theme}
             onHover={onHover}
             active={activeSlug === theme.slug}
+            onLightbox={onLightbox}
           />
         ))}
       </div>
@@ -149,6 +165,7 @@ function MarqueeRow({ themes, duration, reverse, onHover, activeSlug }: MarqueeR
  */
 export function ThemeWall({ className }: { className?: string }) {
   const [active, setActive] = useState<ThemeTile | null>(null)
+  const [lightboxOpen, setLightboxOpen] = useState(false)
   const rows = intoRows(THEMES, 3)
 
   return (
@@ -170,9 +187,9 @@ export function ThemeWall({ className }: { className?: string }) {
       <div className="pointer-events-none absolute inset-y-0 right-0 z-20 w-16 bg-gradient-to-l from-background to-transparent sm:w-28" />
 
       <div className="flex flex-col gap-4">
-        <MarqueeRow themes={rows[0]!} duration={64} onHover={setActive} activeSlug={active?.slug ?? null} />
-        <MarqueeRow themes={rows[1]!} duration={78} reverse onHover={setActive} activeSlug={active?.slug ?? null} />
-        <MarqueeRow themes={rows[2]!} duration={70} onHover={setActive} activeSlug={active?.slug ?? null} />
+        <MarqueeRow themes={rows[0]!} duration={64} onHover={setActive} activeSlug={active?.slug ?? null} paused={lightboxOpen} onLightbox={setLightboxOpen} />
+        <MarqueeRow themes={rows[1]!} duration={78} reverse onHover={setActive} activeSlug={active?.slug ?? null} paused={lightboxOpen} onLightbox={setLightboxOpen} />
+        <MarqueeRow themes={rows[2]!} duration={70} onHover={setActive} activeSlug={active?.slug ?? null} paused={lightboxOpen} onLightbox={setLightboxOpen} />
       </div>
 
       {/* Live caption — name of whatever you're pointing at */}


### PR DESCRIPTION
Feedback pass on the freshly-shipped redesign. All seven items.

## Changes

1. **Theme-wall lightbox (bug).** Clicking a theme opened a lightbox clipped to the marquee row that slid with it — the row's animation `transform` made it the containing block for the overlay's `position: fixed`, and its `overflow: hidden` cropped it. Now the overlay renders through a **portal on `document.body`**, and every marquee row **freezes while a lightbox is open**. Also fixed a latent bug: the `animation` shorthand reset `animation-play-state: running` inline and silently beat the pause utility classes, so hover-pause never worked either — now driven by animation longhands.
2. **Workstation hero.** The full-bleed giant GIF was overwhelming with no context. Reworked into a contained two-column hero: copy + install command + quick stats (16 views / 31 themes / <100ms boot / 0 mouse) beside a tastefully framed demo.
3. **Footer.** Brought back the original typewriter cover illustration as a wink, now that the hero shows the real product.
4. **Chord navigation.** The key reference floated awkwardly above a detached oversized GIF — now paired side by side (reference + sticky live demo).
5. **Cross-view workflows.** Replaced the static card grid with an interactive showcase (same pattern as the view explorer): a selectable flow list drives one large sticky preview that crossfades to a real capture of where each flow lands, lightbox included. Each flow is paired with its best-fit view capture; split/create-PR render AI overlays that can't be captured deterministically, so they point at the surface they're driven from (dedicated captures can be slotted in later).
6. **Get-started section.** Replaced the flat command grid with a two-column terminal-session layout + a real `coco doctor` capture for visual proof.
7. **"How coco stacks up".** Fixed a latent bug (8 rows vs 7 values left the last row blank) by restructuring into a typed, key-based shape; extended 8 → 15 feature rows, added a 5th client (tig), highlighted the coco column, added a glyph legend. Competitor values are a fair-faith snapshot — corrections welcome.

## Validation

- `yarn build` green (type-check + 26 routes).
- Verified in a Next 16 preview: lightbox portals full-screen + pauses the marquee (open→paused, close→running); chord nav and both showcases are 2-col; the cross-view preview swaps on select (Bisect → view-bisect confirmed); comparison table has 15 rows with **0 empty cells**; install is 2-col with the doctor shot; footer carries the cover.