### PR TITLE
content: 37 themes everywhere

### DIFF
--- a/src/app/workstation/page.tsx
+++ b/src/app/workstation/page.tsx
@@ -160,7 +160,7 @@ export default function WorkstationPage() {
       "Bisect workflow with single-keystroke decisions",
       "Reflog browser with one-key drill-in to any HEAD movement",
       "Conflict resolution helper for merge / rebase / cherry-pick / revert",
-      "4 built-in theme presets",
+      "37 built-in theme presets",
       "NO_COLOR support",
     ],
     softwareVersion: "latest",
@@ -213,7 +213,7 @@ export default function WorkstationPage() {
                 <dl className="mt-8 grid w-full max-w-md grid-cols-4 gap-3 border-t border-border/60 pt-6">
                   {[
                     { value: "16", label: "views" },
-                    { value: "31", label: "themes" },
+                    { value: "37", label: "themes" },
                     { value: "<100ms", label: "boot" },
                     { value: "0", label: "mouse" },
                   ].map(({ value, label }) => (
@@ -394,7 +394,7 @@ export default function WorkstationPage() {
           <div className="container">
             <SectionHeader
               prompt="~/coco $ ui --theme"
-              title="Thirty-one ways to make it yours"
+              title="Thirty-seven ways to make it yours"
               subtitle="From Catppuccin to Gruvbox to Synthwave — every preset is a complete palette, surface and all. Plus full NO_COLOR support for minimal environments."
             />
           </div>

--- a/src/components/ThemeWall/index.tsx
+++ b/src/components/ThemeWall/index.tsx
@@ -118,7 +118,7 @@ function MarqueeRow({ themes, duration, reverse, onHover, activeSlug, paused, on
  * alternating directions and pause on hover; hovering a tile lifts it,
  * rings it in the theme's accent, and bleeds that hue into the section.
  * Click any tile for a full-size lightbox. Replaces the old one-at-a-time
- * arrow carousel — 30 palettes shown at once instead of one every click.
+ * arrow carousel — 37 palettes shown at once instead of one every click.
  */
 export function ThemeWall({ className }: { className?: string }) {
   const [active, setActive] = useState<ThemeTile | null>(null)


### PR DESCRIPTION
Update the hardcoded theme counts that the dynamic `THEME_COUNT`/`THEMES.length` didn't cover, now that coco ships **37** built-in themes:

- workstation hero stat: 31 → **37**
- theming section title: "Thirty-one ways…" → "**Thirty-seven** ways to make it yours"
- JSON-LD featureList: a stale "4 built-in theme presets" → **37**
- a ThemeWall code comment

The docs themes page, theme wall caption, and docs index already read 37 (derived from the shared catalog).