### PR TITLE
docs(themes): fix --theme preset list + correct config example

### DIFF
--- a/src/app/_home/sections/Toolbelt.tsx
+++ b/src/app/_home/sections/Toolbelt.tsx
@@ -110,7 +110,7 @@ const commands: (CommandCardProps & { id: string })[] = [
     icon: MonitorIcon,
     flags: [
       { flag: "--view", description: "Open a specific view on launch" },
-      { flag: "--theme", description: "Set color theme (default, monochrome, catppuccin, gruvbox)" },
+      { flag: "--theme", description: "Set color theme — one of 49 built-in presets (see /docs/themes)" },
       { flag: "--all", description: "Show all branches in history" },
       { flag: "--branch", description: "Filter to a specific branch" },
       { flag: "--path", description: "Filter history to a file path" },

--- a/src/app/docs/themes/page.tsx
+++ b/src/app/docs/themes/page.tsx
@@ -106,9 +106,9 @@ export default function ThemesDocsPage() {
             <span className="text-muted-foreground/60">$ </span>coco ui --theme gruvbox
           </code>
           <code className="block rounded-md bg-[hsl(var(--code-bg))] px-3 py-2 font-mono text-sm text-foreground/80">
-            <span className="text-muted-foreground/60"># .coco/config.json</span>
+            <span className="text-muted-foreground/60"># .coco.config.json</span>
             {"  "}
-            <span className="text-terminal-green">{`{ "ui": { "theme": "gruvbox" } }`}</span>
+            <span className="text-terminal-green">{`{ "logTui": { "theme": { "preset": "gruvbox" } } }`}</span>
           </code>
           <p className="text-xs text-muted-foreground">
             Prefer no color at all? Set{" "}


### PR DESCRIPTION
Pre-0.57.0 docs accuracy pass for the marketing/docs site. (The theme counts and view counts elsewhere on the site are already correct — these are the two genuine leftovers a staleness audit surfaced.)

## Fixes

1. **Home toolbelt** (`_home/sections/Toolbelt.tsx`) — the `--theme` flag help listed only four presets (`default, monochrome, catppuccin, gruvbox`). coco ships **49**, so this both undersold the feature and contradicted the rest of the site. Now: *"Set color theme — one of 49 built-in presets (see /docs/themes)"*.

2. **docs/themes config example** (`docs/themes/page.tsx`) — was wrong two ways:
   - file path `# .coco/config.json` → **`.coco.config.json`** (a single dotfile, no `.coco/` dir)
   - the JSON used a nonexistent key: `{ "ui": { "theme": "gruvbox" } }`. `coco ui` reads `logTui.theme.preset` (confirmed in `src/commands/ui/handler.ts`), so it's now `{ "logTui": { "theme": { "preset": "gruvbox" } } }` — matching the README's example.

`tsc --noEmit` clean; `eslint` clean. Swept the rest of `src/` for the same two patterns — no other instances.