### PR TITLE
feat(home): lead install quick-start with bare `coco` smart entry

### DIFF
--- a/src/app/_home/sections/Install.tsx
+++ b/src/app/_home/sections/Install.tsx
@@ -7,6 +7,7 @@ import { SectionHeader } from "@/components/SectionHeader"
 import Image from "next/image"
 
 const quickStartItems = [
+  { command: "coco", description: "Smart entry — opens the workstation in a repo, the setup wizard on a fresh install" },
   { command: "coco commit", description: "AI commit messages from your staged changes" },
   { command: "coco changelog", description: "Generate changelogs for any branch or range" },
   { command: "coco review", description: "Catch issues before you push" },


### PR DESCRIPTION
Surfaces the 0.57.0 smart-routing behavior on the home page. The "Get started → then run any of these" list now leads with bare `coco`:

> `coco` — Smart entry — opens the workstation in a repo, the setup wizard on a fresh install

Pairs with the wiki + README routing docs and the updated 0.57.0 release notes. `tsc` + `eslint` clean.