### PR TITLE
fix(MediaFrame): reveal cached media that loads before hydration

### DIFF
--- a/src/components/MediaFrame/index.tsx
+++ b/src/components/MediaFrame/index.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import Image from "next/image"
-import { useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { cn } from "@/lib/utils"
 import { versionedAsset } from "@/lib/assetVersion"
 
@@ -48,7 +48,19 @@ export function MediaFrame({
   className,
 }: MediaFrameProps) {
   const [loaded, setLoaded] = useState(false)
+  const imgRef = useRef<HTMLImageElement | null>(null)
   const url = versionedAsset(src)
+
+  // A cached image can finish loading before React hydrates and attaches
+  // `onLoad` — so the load event is missed and the media would stay pinned at
+  // opacity-0 forever (most visible on the eager/priority hero, which loads
+  // fastest). Reconcile against the DOM on mount: if the <img> is already
+  // complete, treat it as loaded. Re-checks when the src changes.
+  useEffect(() => {
+    const img = imgRef.current
+    if (img?.complete && img.naturalWidth > 0) setLoaded(true)
+  }, [url])
+
   const fit = objectFit === "contain" ? "object-contain" : "object-cover"
   const fade = cn(
     "transition-opacity duration-500 ease-out",
@@ -69,21 +81,25 @@ export function MediaFrame({
       {kind === "gif" ? (
         // eslint-disable-next-line @next/next/no-img-element
         <img
+          ref={imgRef}
           src={url}
           alt={alt}
           loading={priority ? "eager" : "lazy"}
           onLoad={() => setLoaded(true)}
+          onError={() => setLoaded(true)}
           className={cn("absolute inset-0 h-full w-full", fit, fade)}
           style={{ objectPosition }}
         />
       ) : (
         <Image
+          ref={imgRef}
           src={url}
           alt={alt}
           fill
           priority={priority}
           sizes={sizes}
           onLoad={() => setLoaded(true)}
+          onError={() => setLoaded(true)}
           className={cn(fit, fade)}
           style={{ objectPosition }}
         />


### PR DESCRIPTION
## Symptom

The homepage hero (and other demos) intermittently render **blank** — the dark frame shows but the GIF never appears. Reloading sometimes fixes it.

## Cause

`MediaFrame` starts media at `opacity-0` and only crossfades to visible on the `onLoad` event (`setLoaded(true)`). When the asset is served **from cache**, the browser often finishes loading the `<img>` *before* React hydrates and attaches `onLoad` — the `load` event is missed, `loaded` stays `false`, and the media is stuck at `opacity-0` forever.

It's worst on the **hero** because it's `priority`/eager: it loads fastest and is the most likely to beat hydration. Lazy demos lower on the page hydrate before they scroll into view, so they rarely show it. The randomness is just cache-vs-hydration timing.

## Fix

On mount (and when `src` changes), reconcile against the DOM via a ref: if the `<img>` is already `.complete` with `naturalWidth > 0`, mark it loaded. Also treat `onError` as loaded so a failed asset stops the skeleton rather than shimmering forever. Applies to both the GIF `<img>` and the `next/image` branch.

## Validation

`tsc --noEmit` ✓ · `eslint` ✓ (Node 20.14). No new deps. (No component-test infra in this repo — env is node-only — so not adding a jsdom test for one component; Vercel's preview build exercises the compile.)