### PR TITLE
feat(workstation): document 0.71 expanded git-ops surfaces

### DIFF
--- a/src/app/workstation/page.tsx
+++ b/src/app/workstation/page.tsx
@@ -81,6 +81,7 @@ const chordKeys = [
   { key: "r", label: "Reflog" },
   { key: "B", label: "Bisect" },
   { key: "M", label: "Submodules" },
+  { key: "n", label: "Remotes" },
   { key: "L", label: "Changelog" },
 ]
 

--- a/src/app/workstation/page.tsx
+++ b/src/app/workstation/page.tsx
@@ -30,7 +30,7 @@ import { GifDemo } from "@/components/GifDemo"
 export function generateMetadata(): Metadata {
   const title = "Workstation — Terminal Git Workstation"
   const description =
-    `A keyboard-driven terminal Git workstation with 16 specialized views — including GitHub issue and PR triage, conflict resolution, bisect, recursive submodule navigation, and a full stash workflow — chord navigation, AI-powered commits, one-keystroke PR creation, full-screen changelog generation, tactile hunk-level staging, a single-pane fallback for narrow terminals (80×24 tmux-ready), and ${THEME_COUNT} customizable themes. No Electron, no mouse required.`
+    `A keyboard-driven terminal Git workstation with 18 specialized views — including GitHub issue and PR triage, conflict resolution, bisect, recursive submodule navigation, and a full stash workflow — chord navigation, AI-powered commits, one-keystroke PR creation, full-screen changelog generation, tactile hunk-level staging, a single-pane fallback for narrow terminals (80×24 tmux-ready), and ${THEME_COUNT} customizable themes. No Electron, no mouse required.`
 
   return {
     title,
@@ -136,7 +136,7 @@ export default function WorkstationPage() {
     applicationCategory: "DeveloperApplication",
     operatingSystem: "Linux, macOS, Windows",
     description:
-      `A keyboard-driven terminal Git workstation with 16 specialized views, a full stash workflow, conflict resolution, bisect, and recursive submodule navigation, with chord navigation, AI-powered commits, one-keystroke PR creation, full-screen changelog generation, tactile hunk-level staging, a single-pane fallback for narrow terminals, and ${THEME_COUNT} customizable themes.`,
+      `A keyboard-driven terminal Git workstation with 18 specialized views, a full stash workflow, conflict resolution, bisect, and recursive submodule navigation, with chord navigation, AI-powered commits, one-keystroke PR creation, full-screen changelog generation, tactile hunk-level staging, a single-pane fallback for narrow terminals, and ${THEME_COUNT} customizable themes.`,
     url: `${siteConfig.url}/workstation`,
     offers: {
       "@type": "Offer",
@@ -149,7 +149,7 @@ export default function WorkstationPage() {
       url: siteConfig.author.url,
     },
     featureList: [
-      "16 specialized TUI views",
+      "18 specialized TUI views",
       "Chord-based keyboard navigation",
       "Tactile hunk-level staging",
       "Stash workflow — aligned table, stash-from-anywhere (gZ), rename, branch, undo-drop, apply-index, quick WIP",
@@ -164,6 +164,10 @@ export default function WorkstationPage() {
       "Compare any two refs (branches / tags / commits)",
       "Bisect workflow with single-keystroke decisions",
       "Reflog browser with one-key drill-in to any HEAD movement",
+      "Remotes surface — add / remove / set-url / prune",
+      "Per-file git-blame drill-down",
+      "Submodule init / update / sync",
+      "Rebase the current branch onto any ref",
       "Conflict resolution helper for merge / rebase / cherry-pick / revert",
       `${THEME_COUNT} built-in theme presets`,
       "NO_COLOR support",


### PR DESCRIPTION
Documents the four new 0.71 workstation git-ops surfaces on the workstation page.

- Bumps "16 specialized views" → **18** (remotes + blame are new views).
- Adds four feature-list items: **Remotes** (add/remove/set-url/prune), **per-file git-blame** drill-down, **submodule init/update/sync**, and **rebase the current branch onto any ref**.

Factual copy only — no new assets/screenshots. Builds clean (`/workstation` renders; the pre-existing unrelated `/docs/themes` image-config issue is untouched).

Pairs with the coco 0.71.0 release + the wiki TUI-Navigation update (already pushed). Branch + PR (not pushed to main) so you can eyeball before it deploys.